### PR TITLE
Force numpy > 1.13.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,8 @@ requirements:
     - networkx >=2.1,<3
     - notebook >=5.3.1,<6
     - ntl >=10.3.0,<11
-    - numpy >=1.13.3,<2
+    # Sage uses 1.13.3 but for some reason conda's 1.13.3 causes ImportErrors
+    - numpy >=1.14,<2
     - openblas >=0.2.20
     - palp >=2.1,<3
     # Sage uses an unreleased 2.10 pre-release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 2
   skip: true  # [win]
   skip: true  # [py3k and py<36]
 


### PR DESCRIPTION
it's not clear to me what is the issue but with 1.13.3 there are lots of ImportErrors:
```
ImportError: numpy.core.multiarray failed to import
```

With 1.14 and 1.15 this does not seem to happen.