### PR TITLE
Upgrade to 9.5

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,13 +5,13 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:
@@ -32,6 +32,11 @@ jobs:
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+          export IS_PR_BUILD="True"
+        else
+          export IS_PR_BUILD="False"
+        fi
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,4 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
-zip_keys:
-- - cdt_name
-  - docker_image
+- quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -38,8 +40,8 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
 
@@ -56,7 +58,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null
@@ -64,12 +66,10 @@ else
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
     ( endgroup "Validating outputs" ) 2> /dev/null
-    # we are building with mambabuild, but don't error because conda-build doesn't work
-    # exit 1
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 
-    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -75,12 +75,15 @@ fi
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
+export IS_PR_BUILD="${IS_PR_BUILD:-False}"
+docker pull "${DOCKER_IMAGE}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e IS_PR_BUILD \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
@@ -91,9 +94,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
-           $DOCKER_IMAGE \
+           "${DOCKER_IMAGE}" \
            bash \
-           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           "/home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh"
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ conda search sage --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -13,6 +13,7 @@ import platform
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    os.environ["IS_PR_BUILD"] = "True"
     if ns.debug:
         os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
         if ns.output_id:
@@ -20,6 +21,10 @@ def setup_environment(ns):
     if "MINIFORGE_HOME" not in os.environ:
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
+        )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
         )
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,7 @@ requirements:
     - mpfr
     - mpmath >=1.2.1,<2
     - nauty >=2.7r1,<3
+    - nbclient >=0.5.9,<0.6
     - nbconvert >=5.6.1,<7
     - nbformat >=5.0.7,<6
     - ncurses >=6.0,<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,7 +124,7 @@ requirements:
     - singular
     - six >=1.16.0,<2
     - sphinx >=4.2.0,<5
-    - sqlite >=3.29,<4
+    - sqlite >=3.36,<4
     - symmetrica
     - sympow >=2.023.6,<3
     - sympy >=1.8,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,7 +79,7 @@ requirements:
     - mpmath >=1.2.1,<2
     - nauty >=2.7r1,<3
     - nbclient >=0.5.9,<0.6
-    - nbconvert >=5.6.1,<7
+    - nbconvert >=6.1.0,<7
     - nbformat >=5.0.7,<6
     - ncurses >=6.0,<7
     - networkx >=2.5.1,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,7 @@ requirements:
     - sympow >=2.023.6,<3
     - sympy >=1.9,<2
     - tachyon 0.99.*
-    - terminado >=0.8.3
+    - terminado >=0.12.1
     - three.js 122
     - tornado >=6.0.4,<7
     - traitlets >=4.3.3,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - certifi
     - cliquer
     - cvxopt >=1.2.7,<2
-    - cycler >=0.10.0
+    - cycler >=0.11.0
     - cypari2
     - cysignals
     - cython >=0.29.21

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,7 +131,7 @@ requirements:
     - tachyon 0.99.*
     - terminado >=0.12.1
     - three.js 122
-    - tornado >=6.0.4,<7
+    - tornado >=6.1,<7
     - traitlets >=4.3.3,<6
     - wcwidth >=0.1.7,<2
     - widgetsnbextension >=3.5.1,<4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,7 +102,7 @@ requirements:
     - pynac >=0.7.29,<0.8
     - pyparsing >=2.4.7,<3
     - python >=3.7
-    - python-dateutil >=2.8.1,<3
+    - python-dateutil >=2.8.2,<3
     - pytz >=2020.4
     - pyzmq >=22.0.3
     - ratpoints

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ requirements:
     - sqlite >=3.36,<4
     - symmetrica
     - sympow >=2.023.6,<3
-    - sympy >=1.8,<2
+    - sympy >=1.9,<2
     - tachyon 0.99.*
     - terminado >=0.8.3
     - three.js 122

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,7 +123,7 @@ requirements:
     - simplegeneric >=0.8.1,<1
     - singular
     - six >=1.16.0,<2
-    - sphinx >=4.0.1,<5
+    - sphinx >=4.2.0,<5
     - sqlite >=3.29,<4
     - symmetrica
     - sympow >=2.023.6,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,7 @@ requirements:
     - ptyprocess >=0.5.1,<1
     - pygments >=2.10.0,<3
     - pynac >=0.7.29,<0.8
-    - pyparsing >=2.4.7,<3
+    - pyparsing >=3.0.6,<4
     - python >=3.7
     - python-dateutil >=2.8.2,<3
     - pytz >=2020.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,7 +135,7 @@ requirements:
     - tornado >=6.1,<7
     - traitlets >=5.1.1,<6
     - wcwidth >=0.2.5,<2
-    - widgetsnbextension >=3.5.1,<4
+    - widgetsnbextension >=3.5.2,<4
     - zeromq >=4.2.5,<5
     - zlib
     - zn_poly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - ipykernel >=6.6.0,<7
     - ipython >=7.29,<8
     - ipython_genutils >=0.2.0
-    - ipywidgets >=7.6.3,<8
+    - ipywidgets >=7.6.5,<8
     - jinja2
     - jmol >=14.29.52,<15
     - jsonschema >=3.2.0,<4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,6 +96,7 @@ requirements:
     - planarity
     - ppl
     - pplpy 
+    - primecountpy >=0.1.0,<0.2.0
     - prompt_toolkit >=3.0.22,<4
     - psutil >=5.2.0,<6
     - ptyprocess >=0.5.1,<1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,6 +104,7 @@ requirements:
     - pyparsing >=3.0.6,<4
     - python >=3.7
     - python-dateutil >=2.8.2,<3
+    - pythran >=0.10.0,<0.11
     - pytz >=2020.4
     - pyzmq >=22.0.3
     - ratpoints

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -134,7 +134,7 @@ requirements:
     - three.js 122
     - tornado >=6.1,<7
     - traitlets >=5.1.1,<6
-    - wcwidth >=0.1.7,<2
+    - wcwidth >=0.2.5,<2
     - widgetsnbextension >=3.5.1,<4
     - zeromq >=4.2.5,<5
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cddlib >=1!0.94m
     - certifi
     - cliquer
-    - cvxopt >=1.2.6,<2
+    - cvxopt >=1.2.7,<2
     - cycler >=0.10.0
     - cypari2
     - cysignals

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sage" %}
-{% set version = "9.4" %}
+{% set version = "9.5" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ requirements:
     - planarity
     - ppl
     - pplpy 
-    - prompt_toolkit >=3.0.5,<4
+    - prompt_toolkit >=3.0.22,<4
     - psutil >=5.2.0,<6
     - ptyprocess >=0.5.1,<1
     - pygments >=2.3.1,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -119,7 +119,7 @@ requirements:
     - sagemath-db-graphs >=20210214
     - sagemath-db-polytopes >=20170220
     - sagetex >=3.5
-    - scipy >=1.6.3
+    - scipy >=1.7.2
     - simplegeneric >=0.8.1,<1
     - singular
     - six >=1.15.0,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,7 +136,7 @@ requirements:
     - traitlets >=5.1.1,<6
     - wcwidth >=0.2.5,<2
     - widgetsnbextension >=3.5.2,<4
-    - zeromq >=4.2.5,<5
+    - zeromq >=4.3.4,<5
     - zlib
     - zn_poly
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ requirements:
     - nbformat >=5.1.3,<6
     - ncurses >=6.0,<7
     - networkx >=2.6.3,<3
-    - notebook >=6.1.1,<7
+    - notebook >=6.4.6,<7
     - ntl
     - numpy
     - palp >=2.11,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,7 +105,7 @@ requirements:
     - python >=3.7
     - python-dateutil >=2.8.2,<3
     - pythran >=0.10.0,<0.11
-    - pytz >=2020.4
+    - pytz >=2021.3
     - pyzmq >=22.0.3
     - ratpoints
     - readline

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - gsl
     - iml
     - ipykernel >=6.6.0,<7
-    - ipython >=7.16.1,<8
+    - ipython >=7.29,<8
     - ipython_genutils >=0.2.0
     - ipywidgets >=7.6.3,<8
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,7 +99,7 @@ requirements:
     - prompt_toolkit >=3.0.22,<4
     - psutil >=5.2.0,<6
     - ptyprocess >=0.5.1,<1
-    - pygments >=2.3.1,<3
+    - pygments >=2.10.0,<3
     - pynac >=0.7.29,<0.8
     - pyparsing >=2.4.7,<3
     - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ requirements:
     - scipy >=1.7.2
     - simplegeneric >=0.8.1,<1
     - singular
-    - six >=1.15.0,<2
+    - six >=1.16.0,<2
     - sphinx >=4.0.1,<5
     - sqlite >=3.29,<4
     - symmetrica

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ requirements:
     - nbconvert >=6.1.0,<7
     - nbformat >=5.1.3,<6
     - ncurses >=6.0,<7
-    - networkx >=2.5.1,<3
+    - networkx >=2.6.3,<3
     - notebook >=6.1.1,<7
     - ntl
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ requirements:
     - lrcalc
     - m4ri
     - m4rie
-    - matplotlib-base >=3.3.4,<4
+    - matplotlib-base >=3.5.1,<4
     - maxima >=5.45.0,<6
     - mistune >=0.8.4
     - mpc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - cycler >=0.11.0
     - cypari2
     - cysignals
-    - cython >=0.29.21
+    - cython >=0.29.24
     - decorator >=4.4.2,<5
     - docutils >=0.17.1
     - ecl >=21.2.1,<21.2.2.a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,7 @@ requirements:
     - pkg-config
     - pkgconfig
     - pickleshare >=0.7.5,<1.0
-    - pillow >=8.1.2,<9
+    - pillow >=8.4.0,<9
     - planarity
     - ppl
     - pplpy 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - jinja2
     - jmol >=14.29.52,<15
     - jsonschema >=3.2.0,<4
-    - jupyter_client >=6.1.6,<7
+    - jupyter_client >=7.1.0,<8
     - jupyter_core
     - lcalc
     - libbraiding

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ requirements:
     - ntl
     - numpy
     - palp >=2.11,<3
-    - pari >=2.13.1,<3
+    - pari >=2.13.3,<3
     - pexpect >=4.8.0,<5
     - pkg-config
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,7 +106,7 @@ requirements:
     - python-dateutil >=2.8.2,<3
     - pythran >=0.10.0,<0.11
     - pytz >=2021.3
-    - pyzmq >=22.0.3
+    - pyzmq >=22.3.0,<23
     - ratpoints
     - readline
     - rpy2 >=3.3.6,<4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - gmpy2
     - gsl
     - iml
-    - ipykernel >=5.2.1,<6
+    - ipykernel >=6.6.0,<7
     - ipython >=7.16.1,<8
     - ipython_genutils >=0.2.0
     - ipywidgets >=7.6.3,<8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ requirements:
     - nauty >=2.7r1,<3
     - nbclient >=0.5.9,<0.6
     - nbconvert >=6.1.0,<7
-    - nbformat >=5.0.7,<6
+    - nbformat >=5.1.3,<6
     - ncurses >=6.0,<7
     - networkx >=2.5.1,<3
     - notebook >=6.1.1,<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ requirements:
     - terminado >=0.12.1
     - three.js 122
     - tornado >=6.1,<7
-    - traitlets >=4.3.3,<6
+    - traitlets >=5.1.1,<6
     - wcwidth >=0.1.7,<2
     - widgetsnbextension >=3.5.1,<4
     - zeromq >=4.2.5,<5


### PR DESCRIPTION
fixes #70.

#### Dependencies

* [x] https://github.com/conda-forge/sagelib-feedstock/pull/129

### SPKG Upgrades Upstream

* [x] appnope 0.1.0.p0 → 0.1.2 (not a direct dependency, 0.1.2 available in conda-forge.)
* [x] argcomplete none → 1.12.3 (not a direct dependency, 2.0.0 available in conda-forge.)
* [x] attrs 19.3.0 → 21.2.0 (not a direct dependency, 21.4.0 available in conda-forge.)
* [x] backcall 0.1.0 → 0.2.0 (not a direct dependency, 0.2.0 available in conda-forge.)
* [x] beniget none → 0.4.1 (not a direct dependency, 0.4.1 available in conda-forge.)
* [x] bleach 3.1.5 → 4.1.0 (not a direct dependency, 4.1.0 available in conda-forge.)
* [x] certifi 2020.11.8 → 2021.10.8
* [x] cffi 1.14.5 → 1.15.0 (not a direct dependency, 1.15.0 available in conda-forge.)
* [x] charset_normalizer none → 2.0.4 (not a direct dependency, 2.0.11 available in conda-forge.)
* [x] ~~configure 7282b2b6c6a282a887fa05b0b5250b77035bf3bf → 2e5d421a71304586f059863c84e61e5d0de00be9~~
* [x] cppy none → 1.1.0 (not a direct dependency, 1.1.0 available in conda-forge.)
* [x] cvxopt 1.2.6 → 1.2.7
* [x] cycler 0.10.0.p0 → 0.11.0
* [x] cysignals 1.10.3 → 1.11.2
* [x] cython 0.29.21 → 0.29.24
* [x] database_knotinfo 0.7 → 2021.10.1 (we don't worry about optional dependencies here)
* [x] dateutil 2.8.1 → 2.8.2
* [x] debugpy none → 1.4.1 (we don't worry about optional dependencies here)
* [x] distlib 0.3.1 → 0.3.3 (not a direct dependency, 0.3.4 available in conda-forge.)
* [x] flint 2.7.1 → 2.7.1.p0 (adds a patch for GCC 4.9; not relevant to us.)
* [x] flit_core none → 3.4.0 (not a direct dependency, only a build dependency of backcall which is in conda-forge.)
* [x] fonttools none → 4.28.4 (not a direct dependency)
* [x] gast none → 0.5.2 (not a direct dependency)
* [x] gengetopt none → 2.23 (not a direct dependency)
* [x] gmp 6.2.0 → 6.2.1 (pinned through pinning feedstock)
* [x] gmpy2 2.1.0b5 → 2.1.0rc1
* [x] gsl 2.6 → 2.7 (pinned through pinning feedstock)
* [x] html5lib 1.0.1 → 1.1 (not a direct dependency)
* [x] idna none → 3.2 (not a direct dependency)
* [x] iml 1.0.4p1.p2 → 1.0.4p2.p2 (changes to SPKG build)
* [x] importlib_metadata 4.0.1 → 4.8.2 (not a direct dependency, 4.10 in conda-forge)
* [x] importlib_resources 5.1.4 → 5.2.2 (not a direct dependency, 5.4.0 in conda-forge)
* [x] info none → 6.8 (we don't worry about optional dependencies here)
* [x] ipykernel 5.2.1 → 6.6.0
* [x] ipympl 0.6.3 → 0.7.0 (we don't worry about optional dependencies here)
* [x] ipython 7.16.1 → 7.29.0
* [x] ipywidgets 7.6.3.p0 → 7.6.5
* [x] jedi 0.17.2 → 0.18.1 (not a direct dependency)
* [x] jupyter_client 6.1.6 → 7.1.0
* [x] jupyter_core 4.6.3 → 4.9.1 (was only pinned to version 4, leaving as is; 4.9.1 is in conda-forge.)
* [x] jupyterlab_pygments none → 0.1.2 (not a direct dependency)
* [x] kiwisolver 1.0.1 → 1.3.2 (not a direct dependency)
* [x] lcalc 1.23.p20 → 2.0.5
* [x] liblzma none → ../xz/package-version.txt (not a direct dependency)
* [x] mathics none → 4.0.0 (we don't worry about optional dependencies here)
* [x] mathics_scanner none → 1.2.4 (we don't worry about optional dependencies here)
* [x] matplotlib 3.3.4 → 3.5.1
* [x] matplotlib_inline none → 0.1.2 (not a direct dependency)
* [x] maxima 5.45.0 → 5.45.0.p0 (drops a patch, see https://github.com/conda-forge/maxima-feedstock/pull/29. the patched maxima version **should still work**.)
* [x] memory_allocator 0.1.0 → 0.1.1 (no pin in feedstock, 0.1.2 is in conda-forge.)
* [x] nbclient none → 0.5.9
* [x] nbconvert 5.6.1 → 6.1.0
* [x] nbformat 5.0.7 → 5.1.3
* [x] nest_asyncio none → 1.5.1 (not a direct dependency)
* [x] networkx 2.5.1 → 2.6.3
* [x] notebook 6.1.1 → 6.4.6
* [x] numpy 1.20.3 → 1.21.4 (probably **not relevant** for us)
* [x] openblas 0.3.13 → 0.3.18 (no pin in recipes, 0.3.18 available in conda-forge.)
* [x] openssl 3.0.0-alpha12 → 3.0.1 (indirect dependency)
* [x] packaging 20.9 → 21.0 (indirect dependency)
* [x] palettable none → 3.3.0 (we don't worry about optional dependencies here)
* [x] pandocfilters 1.4.2 → 1.4.3 (not a direct dependency)
* [x] pari 2.13.1 → 2.13.3
* [x] parso 0.7.0 → 0.8.2 (not a direct dependency)
* [x] pillow 8.1.2 → 8.4.0
* [x] pint none → 0.17 (not a direct dependency)
* [x] pip 21.1.2 → 21.3.1 (no pin in recipe)
* [x] pkgconfig 1.5.2 → 1.5.5 (no pin in recipe)
* [x] pluggy 0.13.1 → 1.0.0 (not a direct dependency)
* [x] ply none → 3.11 (not a direct dependency)
* [x] polymake 4.4 → 4.5 (we don't worry about optional dependencies here)
* [x] pplpy_doc none → ../pplpy/package-version.txt (**does not seem to be relevant**)
* [x] primecount 5.1 → 7.1
* [x] primecountpy none → 0.1.0 (https://github.com/conda-forge/staged-recipes/pull/17948)
* [x] primesieve none → 7.6 (not a direct dependency)
* [x] prometheus_client 0.8.0 → 0.11.0 (not a direct dependency)
* [x] prompt_toolkit 3.0.5 → 3.0.22
* [x] pybind11 2.6.0 → 2.8.1 (not a direct dependency)
* [x] pycryptosat none → 5.6.8 (we don't worry about optional dependencies here)
* [x] pygments 2.3.1.p0 → 2.10.0
* [x] pyparsing 2.4.7 → 3.0.6
* [x] pyrsistent 0.16.0 → 0.18.0 (not a direct dependency)
* [x] python3 3.9.5 → 3.9.9 (not relevant here)
* [x] pythran none → 0.10.0
* [x] pytz 2020.4 → 2021.3
* [x] pyzmq 22.0.3 → 22.3.0
* [x] qhull 2015-src-7.2.0.p1 → 2020-src-8.0.2 (not a direct dependency)
* [x] requests 2.13.0 → 2.26.0 (not a direct dependency)
* [x] rst2ipynb 0.2.2.p0 → 0.2.3 (not a direct dependency
* [x] sage_setup none → ../sagelib/package-version.txt (installed explicitly by build.sh.)
* [x] sagelib 9.4 → 9.5 (…)
* [x] scipy 1.6.3 → 1.7.2
* [x] send2trash 1.5.0 → 1.8.0 (not a direct dependency)
* [x] setuptools 56.2.0 → 59.2.0 (not pinned in the recipe currently)
* [x] setuptools_scm 6.0.1 → 6.3.2 (currently, not referenced by the recipe.)
* [x] setuptools_scm_git_archive none → 1.1 (currently, not referenced by the recipe.)
* [x] singular 4.2.0p3 → 4.2.1p3 (https://github.com/conda-forge/singular-feedstock/pull/21)
* [x] sirocco 2.0.2 → 2.1.0 (we don't worry about optional dependencies here)
* [x] six 1.15.0 → 1.16.0
* [x] snowballstemmer 1.2.1.p0 → 2.1.0 (not a direct dependency)
* [x] sphinx 4.0.1.p0 → 4.2.0
* [x] sphinxcontrib_htmlhelp 1.0.3 → 2.0.0 (not a direct dependency)
* [x] sphinxcontrib_serializinghtml 1.1.4 → 1.1.5 (not a direct dependency)
* [x] sqlite 3290000 → 3.36.0
* [x] symengine 0.7.0 → 0.8.1 (we don't worry about optional dependencies here)
* [x] symengine_py 0.7.0.post2 → 0.8.1.p0 (we don't worry about optional dependencies here)
* [x] sympy 1.8 → 1.9
* [x] terminado 0.8.3 → 0.12.1
* [x] testpath 0.4.4 → 0.5.0 (not in the recipe currently, probably **not relevant**)
* [x] tomli none → 1.2.1 (not a direct dependency)
* [x] tornado 6.0.4 → 6.1
* [x] tox 3.23.1 → 3.24.3 (not in the recipe currently, probably **not relevant**)
* [x] traitlets 4.3.3 → 5.1.1
* [x] urllib3 none → 1.26.6 (not a direct dependency)
* [x] virtualenv 20.4.7 → 20.7.2 (not in recipe currently, probably **not relevant**)
* [x] wcwidth 0.1.7.p0 → 0.2.5
* [x] wheel 0.36.2 → 0.37.0 (not in recipe currently, probably **not relevant**)
* [x] widgetsnbextension 3.5.1.p0 → 3.5.2
* [x] xz 5.2.2.p0 → 5.2.5 (not a direct dependency)
* [x] zeromq 4.2.5 → 4.3.4
* [x] zipp 0.5.2 → 3.5.0 (not a direct dependency)

# SPGK Changes Upstream

* [x] argcomplete none → standard (not a direct dependency)
* [x] beniget none → standard (not a direct dependency)
* [x] charset_normalizer none → standard
* [x] cppy none → standard
* [x] debugpy none → optional (we don't worry about optional dependencies here)
* [x] ffmpeg none → optional (we don't worry about optional dependencies here)
* [x] flit_core none → standard
* [x] fonttools none → standard
* [x] gast none → standard
* [x] gengetopt none → standard
* [x] idna none → standard
* [x] imagemagick none → optional (we don't worry about optional dependencies here)
* [x] info none → optional (we don't worry about optional dependencies here)
* [x] jupyterlab_pygments none → standard
* [x] libgraphviz none → optional (we don't worry about optional dependencies here)
* [x] liblzma none → standard
* [x] mathics none → optional (we don't worry about optional dependencies here)
* [x] mathics_scanner none → optional (we don't worry about optional dependencies here)
* [x] matplotlib_inline none → standard
* [x] nbclient none → standard
* [x] nest_asyncio none → standard
* [x] palettable none → optional (we don't worry about optional dependencies here)
* [x] pdf2svg none → optional (we don't worry about optional dependencies here)
* [x] perl_term_readline_gnu experimental → optional (we don't worry about optional dependencies here)
* [x] pint none → optional (we don't worry about optional dependencies here)
* [x] ply none → standard
* [x] polymake experimental → optional (we don't worry about optional dependencies here)
* [x] pplpy_doc none → standard
* [x] primecount optional → standard
* [x] primecountpy none → standard
* [x] primesieve none → standard
* [x] pycryptosat none → optional (we don't worry about optional dependencies here)
* [x] pythran none → standard
* [x] qhull optional → standard
* [x] sage_setup none → standard
* [x] sagemath_doc_html none → standard
* [x] sagemath_doc_pdf none → optional (we don't worry about optional dependencies here)
* [x] setuptools_scm_git_archive none → standard
* [x] tomli none → standard
* [x] urllib3 none → standard