### PR TITLE
Upgrade to 10.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     # are at least 1.0.0, we limit the version to the next major release.
     - alabaster >=0.7.12
     - arb
-    - babel >=2.11.0,<3
+    - babel >=2.12.1,<3
     - bdw-gc >=8.0.4,<9
     - blas-devel
     - bleach >=5.0.1,<6
@@ -28,7 +28,7 @@ requirements:
     - cycler >=0.11.0
     - cypari2
     - cysignals
-    - cython >=0.29.32
+    - cython >=3,<4
     - decorator >=5.1.1,<6
     - docutils >=0.17.1
     - ecl >=21.2.1,<21.2.2.a0
@@ -37,8 +37,8 @@ requirements:
     - entrypoints >=0.4
     - fflas-ffpack >=2.4.3
     - flintqs >=1.0,<2
-    - fplll >=5.4.2,<6
-    - fpylll >=0.5.9
+    - fplll >=5.4.5,<6
+    - fpylll >=0.6.0
     - freetype >=2.10.4,<3
     - gap-defaults >=4.12.2
     - gf2x >=1.3,<2
@@ -69,14 +69,14 @@ requirements:
     - lrcalc >=2.1,<3
     - m4ri
     - m4rie
-    - matplotlib-base >=3.6.2,<4
+    - matplotlib-base >=3.8.0,<4
     - maxima >=5.46.0,<6
     - mistune >=2.0.4
     - mpc
     - mpfi
     - mpfr
     - mpmath >=1.3.0,<2
-    - nauty >=2.7r1,<3
+    - nauty >=2.8.6,<3
     - nbclient >=0.7.0,<0.8
     - nbconvert >=7.2.3,<8
     - nbformat >=5.7.0,<6
@@ -86,24 +86,24 @@ requirements:
     - ntl
     - numpy
     - palp >=2.11,<3
-    - pari >=2.15.2,<3
+    - pari >=2.15.4,<3
     - pexpect >=4.8.0,<5
     - pkg-config
     - pkgconfig
     - pickleshare >=0.7.5,<1.0
-    - pillow >=9.0.1,<10
+    - pillow >=10.1.0,<11
     - planarity
     - ppl
     - pplpy 
     - primecountpy >=0.1.0,<0.2.0
-    - ptyprocess >=0.5.1,<1
+    - ptyprocess >=0.7.0,<1
     - pygments >=2.13.0,<3
-    - pyparsing >=3.0.9,<4
-    - python >=3.7
+    - pyparsing >=3.1.1,<4
+    - python >=3.9
     - python-dateutil >=2.8.2,<3
-    - pythran >=0.12.1,<0.13
-    - pytz >=2022.5
-    - pyzmq >=24.0.1,<25
+    - pythran >=0.14.0,<0.15
+    - pytz >=2023.3.post1
+    - pyzmq >=25.1.1,<26
     - readline
     - rpy2 >=3.4.5,<4
     - rubiks >=20070912
@@ -115,7 +115,7 @@ requirements:
     - sagemath-db-graphs >=20210214
     - sagemath-db-polytopes >=20170220
     - sagetex >=3.6.1,<4
-    - scipy >=1.10.1,<2
+    - scipy >=1.11.3,<2
     - simplegeneric >=0.8.1,<1
     - singular
     - six >=1.16.0,<2
@@ -128,10 +128,10 @@ requirements:
     - terminado >=0.17.0
     - three.js 122
     - tornado >=6.2,<7
-    - traitlets >=5.5.0,<6
+    - traitlets >=5.9.0,<6
     - wcwidth >=0.2.5,<2
-    - widgetsnbextension >=4.0.3,<5
-    - zeromq >=4.3.4,<5
+    - widgetsnbextension >=4.0.8,<5
+    - zeromq >=4.3.5,<5
     - zlib
     - zn_poly
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sage" %}
-{% set version = "10.1" %}
+{% set version = "10.2" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,7 @@ requirements:
     - sagetex >=3.6.1,<4
     - scipy >=1.11.3,<2
     - simplegeneric >=0.8.1,<1
-    - singular
+    - singular >=4.3.2p8,<4.4
     - six >=1.16.0,<2
     - sphinx >=5.2.3,<6
     - sqlite >=3.36,<4


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

##### Dependencies 

* [x] sage 10.1, https://github.com/conda-forge/sage-feedstock/pull/94
* [x] sagelib 10.2 https://github.com/conda-forge/sagelib-feedstock/pull/165
* [x] Upgrade arb 2.22.1→2.23.0
* [x] Upgrade attrs 22.1.0→23.1.0 (indirect or distribution dependency)
* [x] Upgrade babel 2.11.0→2.12.1
* [x] Add cachetools 5.3.1 (indirect or distribution dependency)
* [x] Add calver 2022.6.26 (distribution dependency)
* [x] Upgrade certifi 2022.9.24→2023.7.22
* [x] Add chardet 5.2.0 (tox dependency)
* [x] Upgrade cmake 3.24.3→3.27.3 (indirect or distribution dependency)
* [x] Add colorama 0.4.6 (tox dependency)
* [x] Upgrade configure  (indirect or distribution dependency)
* [x] Upgrade contourpy 1.0.6→1.1.1 (indirect or distribution dependency)
* [ ] Upgrade cypari 2.1.3→2.1.4 needs https://github.com/sagemath/cypari2/issues/143 and then a PR on the cypari feedstock
* [ ] Upgrade cysignals 1.11.2→1.11.4 https://github.com/conda-forge/cysignals-feedstock/pull/50 needs https://github.com/sagemath/cysignals/issues/195
* [x] Upgrade cython 0.29.32.p2→3.0.4
* [x] Upgrade distlib 0.3.6→0.3.7 (indirect or distribution dependency)
* [x] Upgrade editables 0.3→0.5 (indirect or distribution dependency)
* [x] Upgrade fastjsonschema 2.16.2→2.18.0 (indirect or distribution dependency)
* [x] Upgrade filelock 3.8.0→3.12.3 (indirect or distribution dependency)
* [x] Upgrade flint 2.8.4→2.9.0
* [x] Upgrade flit_core 3.7.1→3.9.0 (indirect or distribution dependency)
* [x] Upgrade fonttools 4.28.4→4.42.1 (indirect or distribution dependency)
* [x] Upgrade fplll 5.4.4→5.4.5
* [x] Upgrade fpylll 0.5.9→0.6.0
* [x] Upgrade gast 0.5.3→0.5.4 (indirect or distribution dependency)
* [x] Upgrade gc 8.0.4→8.2.4 (indirect or distribution dependency)
* [x] Upgrade hatch_fancy_pypi_readme 22.8.0→23.1.0 (indirect or distribution dependency)
* [x] Upgrade hatch_vcs 0.2.0→0.3.0 (indirect or distribution dependency)
* [x] Upgrade hatchling 1.11.1→1.18.0 (indirect or distribution dependency)
* [x] Upgrade importlib_metadata 6.0.0→6.8.0 (indirect or distribution dependency)
* [x] Upgrade importlib_resources 5.12.0→6.0.1 (indirect or distribution dependency)
* [x] Add ipympl 0.9.3 (optional)
* [x] Upgrade jupyter_core 4.11.2→4.12.0
* [x] Upgrade jupyter_sphinx 0.3.2→0.4.0.p0 (indirect or distribution dependency)
* [x] Upgrade kissat 3.0.0→3.1.0 (optional)
* [x] Upgrade kiwisolver 1.4.3→1.4.5 (indirect or distribution dependency)
* [x] Upgrade libatomic_ops 7.6.10→7.8.0 (indirect or distribution dependency)
* [x] Upgrade libbraiding 1.1→1.2 https://github.com/conda-forge/libbraiding-feedstock/pull/4
* [x] Upgrade markupsafe 2.1.1→2.1.3 (indirect or distribution dependency)
* [x] Upgrade matplotlib 3.6.2→3.8.0
* [x] Upgrade meson 1.0.1→1.2.3 (indirect or distribution dependency)
* [x] Upgrade meson_python 0.12.1→0.14.0 (indirect or distribution dependency)
* [x] Upgrade msolve 0.4.9→0.5.0 (optional)
* [x] Upgrade nauty 27r1.p1→2.8.6.p1 https://github.com/conda-forge/nauty-feedstock/pull/22
* [x] Upgrade ninja_build 1.11.0→1.11.1 (indirect or distribution dependency)
* [x] Upgrade normaliz 3.10.0→3.10.1 (optional)
* [x] Upgrade numpy 1.23.5→1.26.1
* [x] Upgrade onetbb 2021.7.0→2021.9.0 (optional)
* [x] Upgrade openblas 0.3.23→0.3.25 (done differently)
* [x] Upgrade openssl 3.0.8→3.0.12 (indirect or distribution dependency)
* [x] Upgrade packaging 21.3→23.2 (indirect or distribution dependency)
* [x] Upgrade pari 2.15.2.p1→2.15.4
* [x] Upgrade pillow 9.0.1→10.1.0
* [x] Upgrade pip 22.3.1→23.3.1 (indirect or distribution dependency)
* [x] Upgrade platformdirs 2.5.4→3.11.0 (indirect or distribution dependency)
* [x] Upgrade pluggy 1.0.0→1.3.0 (indirect or distribution dependency)
* [x] Upgrade pplpy 0.8.7→0.8.9 https://github.com/conda-forge/pplpy-feedstock/pull/14
* [x] Upgrade ptyprocess 0.5.1.p0→0.7.0
* [x] Upgrade pybind11 2.10.1→2.11.1 (indirect or distribution dependency)
* [x] Upgrade pyparsing 3.0.9→3.1.1
* [x] Add pyproject_api 1.6.1 (tox dependency)
* [x] Upgrade pyproject_metadata 0.6.1→0.7.1 (indirect or distribution dependency)
* [x] Upgrade pythran 0.12.1→0.14.0
* [x] Upgrade pytz 2022.5→2023.3.post1
* [x] Upgrade pyzmq 24.0.1→25.1.1
* [x] Upgrade scipy 1.10.1→1.11.3
* [x] Upgrade send2trash 1.8.0→1.8.2 (indirect or distribution dependency)
* [x] Upgrade setuptools 63.4.3→68.2.2 (indirect or distribution dependency)
* [x] Upgrade setuptools_scm 7.0.5→8.0.4 (indirect or distribution dependency)
* [x] Upgrade singular 4.3.1p3→4.3.2p8 https://github.com/conda-forge/singular-feedstock/pull/25
* [x] Upgrade tox 3.27.0→4.11.1 (indirect or distribution dependency)
* [x] Upgrade traitlets 5.5.0→5.9.0
* [x] Add trove_classifiers 2023.8.7 (hatchling dependency)
* [x] Upgrade typing_extensions 4.5.0→4.7.1 (indirect or distribution dependency)
* [x] Upgrade tzlocal 4.2→5.0.1 (indirect or distribution dependency)
* [x] Upgrade virtualenv 20.16.6→20.24.4 (indirect or distribution dependency)
* [x] Upgrade wheel 0.38.4→0.41.2 (indirect or distribution dependency)
* [x] Upgrade widgetsnbextension 4.0.3→4.0.8
* [x] Upgrade zeromq 4.3.4→4.3.5