### PR TITLE
Upgrade to 10.3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,6 +13,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,7 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -6,3 +10,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
@@ -74,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,7 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default}
-conda_build_tool: mamba
+conda_build_tool: conda-build+conda-libmamba-solver
 github:
   branch_name: main
   tooling_branch_name: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,7 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default}
-build_with_mambabuild: true
+conda_build_tool: mamba
 github:
   branch_name: main
   tooling_branch_name: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default}
-conda_build_tool: conda-build+conda-libmamba-solver
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - jinja2
     - jmol >=14.29.52,<15
     - jsonschema >=4.17.3,<5
-    - jupyter_client >=8.3.1,<8
+    - jupyter_client >=8.3.1,<9
     - jupyter_core >=5.3.2,<6
     - lcalc
     - libbraiding

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,24 @@ requirements:
     # We require all dependencies with at least that version that upstream uses
     # in their SPKGs. For packages that (seem to) use semantic versioning and
     # are at least 1.0.0, we limit the version to the next major release.
-    - alabaster >=0.7.12
+    - alabaster >=0.7.16
     - arb
-    - babel >=2.12.1,<3
+    - babel >=2.14.0,<3
     - bdw-gc >=8.0.4,<9
     - blas-devel
-    - bleach >=5.0.1,<6
+    - bleach >=6.1.0,<7
     - brial
     - cddlib >=1!0.94m
     - certifi
     - cliquer
-    - cvxopt >=1.3.0,<2
+    - cvxopt >=1.3.2,<2
     - cycler >=0.11.0
     - cypari2
     - cysignals
     - cython >=3,<4
     - decorator >=5.1.1,<6
-    - docutils >=0.17.1
-    - ecl >=21.2.1,<21.2.2.a0
+    - docutils >=0.20.1
+    - ecl >=23.9.9,<24
     - eclib
     - ecm
     - entrypoints >=0.4
@@ -51,13 +51,13 @@ requirements:
     - gsl
     - iml
     - ipykernel >=6.6.0,<7
-    - ipython >=8.6.0,<9
-    - ipywidgets >=8.0.2,<9
+    - ipython >=8.18.1,<9
+    - ipywidgets >=8.1.1,<9
     - jinja2
     - jmol >=14.29.52,<15
-    - jsonschema >=4.17.1,<5
-    - jupyter_client >=7.4.4,<8
-    - jupyter_core
+    - jsonschema >=4.17.3,<5
+    - jupyter_client >=8.3.1,<8
+    - jupyter_core >=5.3.2,<6
     - lcalc
     - libbraiding
     - libflint
@@ -76,18 +76,18 @@ requirements:
     - mpfi
     - mpfr
     - mpmath >=1.3.0,<2
-    - nauty >=2.8.6,<3
-    - nbclient >=0.7.0,<0.8
-    - nbconvert >=7.2.3,<8
-    - nbformat >=5.7.0,<6
+    - nauty >=2.8.8,<3
+    - nbclient >=0.8.0,<0.9
+    - nbconvert >=7.9.2,<8
+    - nbformat >=5.9.2,<6
     - ncurses >=6.3,<7
-    - networkx >=3.1,<4
-    - notebook >=6.4.10,<7
+    - networkx >=3.2.1,<4
+    - notebook >=7.1.1,<8
     - ntl
     - numpy
     - palp >=2.11,<3
     - pari >=2.15.4,<3
-    - pexpect >=4.8.0,<5
+    - pexpect >=4.9.0,<5
     - pkg-config
     - pkgconfig
     - pickleshare >=0.7.5,<1.0
@@ -97,7 +97,7 @@ requirements:
     - pplpy 
     - primecountpy >=0.1.0,<0.2.0
     - ptyprocess >=0.7.0,<1
-    - pygments >=2.13.0,<3
+    - pygments >=2.17.2,<3
     - pyparsing >=3.1.1,<4
     - python >=3.9
     - python-dateutil >=2.8.2,<3
@@ -110,27 +110,27 @@ requirements:
     - rw
     - sagelib {{ version }}
     - sagemath-db-combinatorial-designs >=20140630
-    - sagemath-db-conway-polynomials >=0.5
+    - sagemath-db-conway-polynomials >=0.8
     - sagemath-db-elliptic-curves >=0.8.1
     - sagemath-db-graphs >=20210214
     - sagemath-db-polytopes >=20170220
     - sagetex >=3.6.1,<4
-    - scipy >=1.11.3,<2
+    - scipy >=1.11.4,<2
     - simplegeneric >=0.8.1,<1
     - singular >=4.3.2p8,<4.4
     - six >=1.16.0,<2
-    - sphinx >=5.2.3,<6
+    - sphinx >=7.2.6,<8
     - sqlite >=3.36,<4
     - symmetrica
     - sympow >=2.023.6,<3
     - sympy >=1.12,<2
     - tachyon 0.99.*
-    - terminado >=0.17.0
+    - terminado >=0.17.1
     - three.js 122
-    - tornado >=6.2,<7
-    - traitlets >=5.9.0,<6
-    - wcwidth >=0.2.5,<2
-    - widgetsnbextension >=4.0.8,<5
+    - tornado >=6.4,<7
+    - traitlets >=5.14.0,<6
+    - wcwidth >=0.2.12,<2
+    - widgetsnbextension >=4.0.9,<5
     - zeromq >=4.3.5,<5
     - zlib
     - zn_poly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,10 +89,10 @@ requirements:
     - palp >=2.11,<3
     - pari >=2.15.4,<3
     - pexpect >=4.9.0,<5
-    - pkg-config
-    - pkgconfig
     - pickleshare >=0.7.5,<1.0
     - pillow >=10.1.0,<11
+    - pkg-config
+    - pkgconfig
     - planarity
     - ppl
     - pplpy 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cddlib >=1!0.94m
     - certifi
     - cliquer
+    - conway-polynomials >=0.8
     - cvxopt >=1.3.2,<2
     - cycler >=0.11.0
     - cypari2
@@ -110,7 +111,6 @@ requirements:
     - rw
     - sagelib {{ version }}
     - sagemath-db-combinatorial-designs >=20140630
-    - sagemath-db-conway-polynomials >=0.8
     - sagemath-db-elliptic-curves >=0.8.1
     - sagemath-db-graphs >=20210214
     - sagemath-db-polytopes >=20170220

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sage" %}
-{% set version = "10.2" %}
+{% set version = "10.3" %}
 
 package:
   name: {{ name }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -19,9 +19,7 @@ export SAGE_ROOT=$PWD
 ls $SAGE_ROOT
 ls $SAGE_LOCAL
 echo $SAGE_ROOT > "$SAGE_LOCAL/lib/sage-current-location.txt"
-sed -i.bak "s@SAGE_ROOT=\"$PREFIX\"@SAGE_ROOT=\"$SAGE_ROOT\"@g" $PREFIX/bin/sage-env-config
 
-export SAGE_NUM_THREADS_PARALLEL=$CPU_COUNT
 export SAGE_NUM_THREADS=$CPU_COUNT
 
 set +e


### PR DESCRIPTION
Fixes #96.

##### Dependencies:

* [x] https://github.com/conda-forge/normaliz-feedstock/pull/53
* [x] Upgrade GAP to FLINT 3 (requires normaliz, see https://conda-forge.org/status/migration/libflint30)
* [x] https://github.com/conda-forge/sagelib-feedstock/pull/174

##### Dependency changes

* [x] sagelib 10.2 → 10.3
* [x] alabaster 0.7.12 → 0.7.16
* [x] anyio missing → 4.0.0 (does not seem relevant)
* [x] arrow missing → 1.3.0 (does not seem relevant)
* [x] asttokens 2.1.0 → 2.4.1 (not a dependency currently)
* [x] async_lru missing → 2.0.4 (does not seem relevant)
* [x] babel 2.12.1 → 2.14.0
* [x] beautifulsoup4 4.11.1 → 4.12.2 (not a dependency currently)
* [x] bleach 5.0.1 → 6.1.0
* [x] certifi 2023.7.22 → 2023.11.17 (should be up-to-date already)
* [x] charset_normalizer 2.1.1 → 3.3.2 (not a dependency currently)
* [x] cmake 3.27.3 → 3.27.8 (not a dependency currently)
* [x] comm missing → 0.1.4 (does not seem relevant)
* [x] configure (not relevant for us)
* [x] conway_polynomials 0.5 → 0.8
* [x] cvxopt 1.3.0 → 1.3.2
* [x] cvxpy 1.3.0 → 1.4.1 (not a dependency currently)
* [x] cylp 0.91.5 → 0.92.2
* [x] cython 3.0.4 → 3.0.7 (should be up-to-date)
* [x] database_knotinfo 2023.6.1 → 2024.2.1 (not a dependency currently)
* [x] debugpy 1.6.3 → 1.8.0 (not a dependency currently)
* [x] distlib 0.3.7 → 0.3.8 (not a dependency currently)
* [x] docutils 0.19 → 0.20.1
* [x] e_antic 1.3.0 → 2.0.0 (not a dependency currently)
* [x] ecl 21.2.1 → 23.9.9 (update not needed)
* [x] eclib 20230424 → 20231212 (should be up-to-date)
* [x] exceptiongroup missing → 1.2.0 (does not seem relevant)
* [x] filelock 3.12.3 → 3.13.1 (not a dependency currently)
* [x] flint 2.9.0 → 3.0.1 (need to pull in migration)
* [x] fqdn missing → 1.5.1 (does not seem relevant)
* [x] furo 2022.9.29 → 2023.9.10 (not a dependency currently)
* [x] gmp 6.2.1 → 6.3.0 (already on conda-forge)
* [x] gmpy2 2.1.2 → 2.2.0a1 (update not needed)
* [x] gnumake_tokenpool missing → 0.0.4 (does not seem relevant)
* [x] h11 missing → 0.14.0 (does not seem relevant)
* [x] hatch_vcs 0.3.0 → 0.4.0 (does not seem relevant)
* [x] hatchling 1.18.0 → 1.20.0 (does not seem relevant)
* [x] httpcore missing → 1.0.4 (does not seem relevant)
* [x] httpx missing → 0.27.0 (does not seem relevant)
* [x] idna 3.4 → 3.6 (not a dependency currently)
* [x] igraph 0.10.4 → 0.10.8 (not a dependency currently)
* [x] importlib_metadata 6.8.0 → 7.0.1 (not a dependency currently)
* [x] importlib_resources 6.0.1 → 6.1.1 (not a dependency currently)
* [x] ipykernel 6.6.0 → 6.27.1 (not a dependency currently)
* [x] ipython 8.6.0 → 8.18.1
* [x] ipywidgets 8.0.2 → 8.1.1
* [x] isoduration missing → 20.11.0 (does not seem relevant)
* [x] jedi 0.18.1 → 0.19.1 (not a dependency currently)
* [x] jinja2 3.1.2 → 3.1.3 (the exact pin probably does not matter)
* [x] json5 missing → 0.9.14 (does not seem relevant)
* [x] jsonpointer missing → 2.4 (does not seem relevant)
* [x] jsonschema 4.17.1 → 4.17.3
* [x] jsonschema_specifications missing → 2023.3.3 (does not seem relevant)
* [x] jupyter_client 7.4.4 → 8.3.1
* [x] jupyter_core 4.12.0 → 5.3.2
* [x] jupyter_events missing → 0.6.3 (does not seem relevant)
* [x] jupyter_lsp missing → 2.2.0 (does not seem relevant)
* [x] jupyter_server missing → 2.7.3 (does not seem relevant)
* [x] jupyter_server_terminals missing → 0.4.4 (does not seem relevant)
* [x] jupyterlab missing → 4.1.3 (does not seem relevant)
* [x] jupyterlab_mathjax2 missing → 4.0.0 (does not seem relevant)
* [x] jupyterlab_pygments 0.1.2 → 0.2.2 (does not seem relevant)
* [x] jupyterlab_server missing → 2.24.0 (does not seem relevant)
* [x] jupyterlab_widgets 3.0.3 → 3.0.9 (does not seem relevant)
* [x] markupsafe 2.1.3 → 2.1.4 (not a dependency currently)
* [x] matroid_database missing → 0.2 (does not seem relevant)
* [x] meson 1.2.3 → 1.3.1 (not a dependency currently)
* [x] meson_python 0.14.0 → 0.15.0 (not a dependency currently)
* [x] mpc 1.1.0 → 1.3.1 (the exact pin probably does not matter)
* [x] mpfr 4.0.1.p0 → 4.2.1 (the exact pin probably does not matter)
* [x] mpfrcx 0.5 → 0.6.3 (not a dependency currently)
* [x] nauty 2.8.6.p1 → 2.8.8.p0
* [x] nbclient 0.7.0 → 0.8.0
* [x] nbconvert 7.2.3 → 7.9.2
* [x] nbformat 5.7.0 → 5.9.2
* [x] nest_asyncio 1.5.6 → 1.5.8 (not a dependency currently)
* [x] networkx 3.1 → 3.2.1
* [x] normaliz 3.10.1 → 3.10.1.p0 (not a dependency currently)
* [x] notebook 6.4.12 → 7.1.1
* [x] notebook_shim missing → 0.2.3 (does not seem relevant)
* [x] numpy 1.26.1 → 1.26.3 (the exact pin probably does not matter)
* [x] openblas 0.3.25 → 0.3.26 (the exact pin probably does not matter)
* [x] osqp_python 0.6.2.post8 → 0.6.3 (not a dependency currently)
* [x] overrides missing → 7.4.0 (does not seem relevant)
* [x] pathspec 0.10.2 → 0.12.1 (not a dependency currently)
* [x] pexpect 4.8.0 → 4.9.0
* [x] platformdirs 3.11.0 → 4.1.0 (not a dependency currently)
* [x] polymake 4.9 → 4.11 (not a dependency currently)
* [x] prompt_toolkit 3.0.24 → 3.0.43 (not a dependency currently)
* [x] psutil missing → 5.9.6 (does not seem relevant)
* [x] pygments 2.13.0 → 2.17.2
* [x] pynormaliz 2.18 → 2.18.p0 (not a dependency currently)
* [x] pyrsistent 0.19.2 → 0.19.3 (not a dependency currently)
* [x] python_igraph 0.10.4 → 0.11.3 (not a dependency currently)
* [x] python_json_logger missing → 2.0.7 (does not seem relevant)
* [x] pyyaml missing → 6.0.1 (does not seem relevant)
* [x] qepcad B.1.72 → 1.74 (not a dependency currently)
* [x] referencing missing → 0.23.0 (does not seem relevant)
* [x] requests 2.28.1 → 2.31.0 (does not seem relevant)
* [x] rfc3339_validator missing → 0.1.4 (does not seem relevant)
* [x] rfc3986_validator missing → 0.1.1 (does not seem relevant)
* [x] saclib 2.2.7 → 2.2.8 (not a dependency currently)
* [x] scipy 1.11.3 → 1.11.4
* [x] scs 3.2.2 → 3.2.3 (not a dependency currently)
* [x] setuptools 68.2.2 → 69.0.2 (the exact pin should not matter)
* [x] sniffio missing → 1.3.0 (does not seem relevant)
* [x] soupsieve 2.3.2.post1 → 2.5 (not a dependency currently)
* [x] sphinx 5.2.3 → 7.2.6
* [x] sphinx_basic_ng 0.0.1a12 → 1.0.0b2 (not a dependency currently)
* [x] sphinx_copybutton 0.5.1 → 0.5.2 (not a dependency currently)
* [x] sphinx_inline_tabs missing → 2023.4.21 (does not seem relevant)
* [x] sphinxcontrib_applehelp 1.0.2 → 1.0.8 (not a dependency currently)
* [x] sphinxcontrib_devhelp 1.0.2 → 1.0.6 (not a dependency currently)
* [x] sphinxcontrib_htmlhelp 2.0.0 → 2.0.5 (not a dependency currently)
* [x] sphinxcontrib_qthelp 1.0.3 → 1.0.7 (not a dependency currently)
* [x] sphinxcontrib_serializinghtml 1.1.5 → 1.1.10 (not a dependency currently)
* [x] sphinxcontrib_websupport 1.2.4 → 1.2.7 (not a dependency currently)
* [x] stack_data 0.6.1 → 0.6.3 (not a dependency currently)
* [x] symengine 0.10.1 → 0.11.2 (not a dependency currently)
* [x] symengine_py 0.10.0 → 0.11.0 (not a dependency currently)
* [x] terminado 0.17.0 → 0.17.1
* [x] texttable 1.6.7 → 1.7.0 (not a dependency currently)
* [x] tornado 6.2 → 6.4
* [x] traitlets 5.9.0 → 5.14.0
* [x] trove_classifiers 2023.8.7 → 2023.11.29 (not a dependency currently)
* [x] types_python_dateutil missing → 2.8.19.14 (does not seem relevant)
* [x] typing_extensions 4.7.1 → 4.8.0 (not a dependency currently)
* [x] tzdata 2022.6 → 2023.3 (not a dependency currently)
* [x] uri_template missing → 1.3.0 (does not seem relevant)
* [x] urllib3 1.26.12 → 2.1.0 (not a dependency currently)
* [x] virtualenv 20.24.4 → 20.25.0 (not a dependency currently)
* [x] wcwidth 0.2.5 → 0.2.12
* [x] webcolors missing → 1.13 (does not seem relevant)
* [x] websocket_client missing → 1.6.4 (does not seem relevant)
* [x] wheel 0.41.2 → 0.42.0 (the exact version should not matter)
* [x] widgetsnbextension 4.0.8 → 4.0.9
* [x] zipp 3.11.0 → 3.17.0 (not a dependency currently)